### PR TITLE
Add maven-compiler-plugin to server example

### DIFF
--- a/examples/server-no-spring/pom.xml
+++ b/examples/server-no-spring/pom.xml
@@ -9,6 +9,14 @@
   <build>
     <plugins>
       <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>2.3.2</version>
+        <configuration>
+          <source>1.7</source>
+          <target>1.7</target>
+        </configuration>
+      </plugin>
+      <plugin>
        <groupId>com.theoryinpractise</groupId>
        <artifactId>clojure-maven-plugin</artifactId>
        <version>1.3.10</version>

--- a/examples/server/pom.xml
+++ b/examples/server/pom.xml
@@ -10,6 +10,14 @@
   <build>
     <plugins>
       <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.3.2</version>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+      </plugin>
+      <plugin>
        <groupId>com.theoryinpractise</groupId>
        <artifactId>clojure-maven-plugin</artifactId>
        <version>1.3.10</version>


### PR DESCRIPTION
Build on Ubuntu 14.04 fails without it with error _annotations are not supported in "-source 1.3"_.
After adding compiler plugin to pom.xml, build goes through.